### PR TITLE
modernize portability policies and privacy controls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/portapps/phyrox-developer-portable
 go 1.26.0
 
 require (
-	github.com/Jeffail/gabs v1.4.0
 	github.com/pierrec/lz4/v3 v3.3.5
 	github.com/pkg/errors v0.9.1
 	github.com/portapps/portapps/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 code.cloudfoundry.org/bytefmt v0.0.0-20190710193110-1eb035ffe2b6/go.mod h1:wN/zk7mhREp/oviagqUXY3EwuHhWyOvAdsn5Y4CzOrc=
-github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
-github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -4,13 +4,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/Jeffail/gabs"
 	"github.com/pkg/errors"
 	"github.com/portapps/phyrox-developer-portable/assets"
 	"github.com/portapps/portapps/v3"
@@ -22,9 +21,11 @@ import (
 )
 
 type config struct {
-	Profile           string `yaml:"profile" mapstructure:"profile"`
-	MultipleInstances bool   `yaml:"multiple_instances" mapstructure:"multiple_instances"`
-	Cleanup           bool   `yaml:"cleanup" mapstructure:"cleanup"`
+	Profile              string `yaml:"profile" mapstructure:"profile"`
+	MultipleInstances    bool   `yaml:"multiple_instances" mapstructure:"multiple_instances"`
+	DisableTelemetry     bool   `yaml:"disable_telemetry" mapstructure:"disable_telemetry"`
+	DisableCrashReporter bool   `yaml:"disable_crash_reporter" mapstructure:"disable_crash_reporter"`
+	Cleanup              bool   `yaml:"cleanup" mapstructure:"cleanup"`
 }
 
 var (
@@ -37,9 +38,11 @@ func init() {
 
 	// Default config
 	cfg = &config{
-		Profile:           "default",
-		MultipleInstances: false,
-		Cleanup:           false,
+		Profile:              "default",
+		MultipleInstances:    false,
+		DisableTelemetry:     false,
+		DisableCrashReporter: true,
+		Cleanup:              false,
 	}
 
 	// Init app
@@ -54,25 +57,28 @@ func main() {
 
 	app.Process = filepath.Join(app.AppPath, "firefox.exe")
 	app.Args = []string{
-		"--profile",
+		"-profile",
 		profileFolder,
 	}
 
 	// Set env vars
 	crashreporterFolder := utl.CreateFolder(app.DataPath, "crashreporter")
 	pluginsFolder := utl.CreateFolder(app.DataPath, "plugins")
-	os.Setenv("MOZ_CRASHREPORTER", "0")
 	os.Setenv("MOZ_CRASHREPORTER_DATA_DIRECTORY", crashreporterFolder)
-	os.Setenv("MOZ_CRASHREPORTER_DISABLE", "1")
-	os.Setenv("MOZ_CRASHREPORTER_NO_REPORT", "1")
-	os.Setenv("MOZ_DATA_REPORTING", "0")
 	os.Setenv("MOZ_MAINTENANCE_SERVICE", "0")
 	os.Setenv("MOZ_PLUGIN_PATH", pluginsFolder)
 	os.Setenv("MOZ_UPDATER", "0")
+	if cfg.DisableCrashReporter {
+		os.Setenv("MOZ_CRASHREPORTER", "0")
+		os.Setenv("MOZ_CRASHREPORTER_DISABLE", "1")
+		os.Setenv("MOZ_CRASHREPORTER_NO_REPORT", "1")
+	}
+	if cfg.DisableTelemetry {
+		os.Setenv("MOZ_DATA_REPORTING", "0")
+	}
 
 	// Create and check mutex
 	mu, err := mutex.Create(app.ID)
-	defer mutex.Release(mu)
 	if err != nil {
 		if !cfg.MultipleInstances {
 			log.Error().Msg("You have to enable multiple instances in your configuration if you want to launch another instance")
@@ -86,15 +92,17 @@ func main() {
 		} else {
 			log.Warn().Msg("Another instance is already running")
 		}
+	} else {
+		defer mutex.Release(mu)
 	}
 
 	// Cleanup on exit
 	if cfg.Cleanup {
 		defer func() {
 			utl.Cleanup([]string{
-				path.Join(os.Getenv("APPDATA"), "Mozilla", "Firefox"),
-				path.Join(os.Getenv("LOCALAPPDATA"), "Mozilla", "Firefox"),
-				path.Join(os.Getenv("USERPROFILE"), "AppData", "LocalLow", "Mozilla"),
+				filepath.Join(os.Getenv("APPDATA"), "Mozilla", "Firefox"),
+				filepath.Join(os.Getenv("LOCALAPPDATA"), "Mozilla", "Firefox"),
+				filepath.Join(os.Getenv("USERPROFILE"), "AppData", "LocalLow", "Mozilla"),
 			})
 		}()
 	}
@@ -102,7 +110,7 @@ func main() {
 	// Multiple instances
 	if cfg.MultipleInstances {
 		log.Info().Msg("Multiple instances enabled")
-		app.Args = append(app.Args, "--no-remote")
+		app.Args = append(app.Args, "-no-remote")
 	}
 
 	// Policies
@@ -116,7 +124,7 @@ func main() {
 	}
 
 	// Copy default shortcut
-	shortcutPath := path.Join(os.Getenv("APPDATA"), "Microsoft", "Windows", "Start Menu", "Programs", "Phyrox Developer Edition Portable.lnk")
+	shortcutPath := filepath.Join(os.Getenv("APPDATA"), "Microsoft", "Windows", "Start Menu", "Programs", "Phyrox Developer Edition Portable.lnk")
 	defaultShortcut, err := assets.Asset("FirefoxDeveloperEdition.lnk")
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot load asset FirefoxDeveloperEdition.lnk")
@@ -151,20 +159,14 @@ func main() {
 func createPolicies() error {
 	appFile := filepath.Join(utl.CreateFolder(app.AppPath, "distribution"), "policies.json")
 	dataFile := filepath.Join(app.DataPath, "policies.json")
-	defaultPolicies := struct {
-		Policies map[string]interface{} `json:"policies"`
-	}{
-		Policies: map[string]interface{}{
-			"DisableAppUpdate":        true,
-			"DontCheckDefaultBrowser": true,
-		},
+	jsonPolicies := map[string]interface{}{
+		"policies": map[string]interface{}{},
 	}
-
-	jsonPolicies, err := gabs.Consume(defaultPolicies)
+	defaultPolicies, err := json.Marshal(jsonPolicies)
 	if err != nil {
-		return errors.Wrap(err, "Cannot consume default policies")
+		return errors.Wrap(err, "Cannot marshal default policies")
 	}
-	log.Debug().Msgf("Default policies: %s", jsonPolicies.String())
+	log.Debug().Msgf("Default policies: %s", string(defaultPolicies))
 
 	if utl.Exists(dataFile) {
 		rawCustomPolicies, err := os.ReadFile(dataFile)
@@ -172,19 +174,37 @@ func createPolicies() error {
 			return errors.Wrap(err, "Cannot read custom policies")
 		}
 
-		jsonPolicies, err = gabs.ParseJSON(rawCustomPolicies)
-		if err != nil {
+		if err := json.Unmarshal(rawCustomPolicies, &jsonPolicies); err != nil {
 			return errors.Wrap(err, "Cannot consume custom policies")
 		}
-		log.Debug().Msgf("Custom policies: %s", jsonPolicies.String())
-
-		jsonPolicies.Set(true, "policies", "DisableAppUpdate")
-		jsonPolicies.Set(true, "policies", "DontCheckDefaultBrowser")
+		customPolicies, err := json.Marshal(jsonPolicies)
+		if err != nil {
+			return errors.Wrap(err, "Cannot marshal custom policies")
+		}
+		log.Debug().Msgf("Custom policies: %s", string(customPolicies))
 	}
 
-	log.Debug().Msgf("Applied policies: %s", jsonPolicies.String())
-	err = os.WriteFile(appFile, []byte(jsonPolicies.StringIndent("", "  ")), 0644)
+	policies, ok := jsonPolicies["policies"].(map[string]interface{})
+	if !ok {
+		if _, exists := jsonPolicies["policies"]; exists {
+			return errors.New("policies must be an object")
+		}
+		policies = map[string]interface{}{}
+		jsonPolicies["policies"] = policies
+	}
+	policies["DisableAppUpdate"] = true
+	policies["DontCheckDefaultBrowser"] = true
+	if cfg.DisableTelemetry {
+		policies["DisableFirefoxStudies"] = true
+		policies["DisableTelemetry"] = true
+	}
+
+	appliedPolicies, err := json.MarshalIndent(jsonPolicies, "", "  ")
 	if err != nil {
+		return errors.Wrap(err, "Cannot marshal policies")
+	}
+	log.Debug().Msgf("Applied policies: %s", string(appliedPolicies))
+	if err := os.WriteFile(appFile, appliedPolicies, 0644); err != nil {
 		return errors.Wrap(err, "Cannot write policies")
 	}
 
@@ -192,7 +212,7 @@ func createPolicies() error {
 }
 
 func updateAddonStartup(profileFolder string) error {
-	lz4File := path.Join(profileFolder, "addonStartup.json.lz4")
+	lz4File := filepath.Join(profileFolder, "addonStartup.json.lz4")
 	if !utl.Exists(lz4File) || app.Prev.RootPath == "" {
 		return nil
 	}


### PR DESCRIPTION
- Added `disable_telemetry` config option.
- Added `disable_crash_reporter` config option, enabled by default.
- Disabled Firefox Studies automatically when telemetry is disabled.
- Modernized `policies.json` handling and kept custom `data/policies.json` support.
- Made crash reporter environment variables conditional.
